### PR TITLE
Handle 404 when no weekly menu

### DIFF
--- a/services/api/app/app.py
+++ b/services/api/app/app.py
@@ -36,7 +36,7 @@ def get_public_weekly_menu(db: Session = Depends(get_db)):
         .first()
     )
     if not weekly:
-        return None
+        raise HTTPException(status_code=404, detail="WeeklyMenu não encontrado")
     return weekly       # agora contém days=[]
 
 

--- a/services/web/app/src/app/(public)/menu/page.tsx
+++ b/services/web/app/src/app/(public)/menu/page.tsx
@@ -148,7 +148,7 @@ function MealCard({ meal, mealType, allAllergens }: { meal?: MenuEntry; mealType
 export default function PublicMenuPage() {
   const [selectedAllergens, setSelectedAllergens] = useState<string[]>([]);
 
-  const { data: weeklyMenu, isLoading: isLoadingMenu, isError: isErrorMenu, error: menuError } = useQuery<WeeklyMenu, Error>({
+  const { data: weeklyMenu, isLoading: isLoadingMenu, isError: isErrorMenu, error: menuError } = useQuery<WeeklyMenu | null, Error>({
     queryKey: ['publicWeeklyMenu'],
     queryFn: getPublicWeeklyMenu,
   });

--- a/services/web/app/src/services/menuService.ts
+++ b/services/web/app/src/services/menuService.ts
@@ -1,5 +1,6 @@
 // src/services/menuService.ts
 import apiClient from '@/lib/api-client';
+import axios from 'axios';
 import type { WeeklyMenu, MenuEntry, DayMenu } from '@/lib/types';
 
 // Assuming API returns a structure similar to WeeklyMenu
@@ -7,10 +8,17 @@ import type { WeeklyMenu, MenuEntry, DayMenu } from '@/lib/types';
 // The admin endpoint for menus would be different, e.g., '/menus/weekly'
 
 // ✅ Buscar o menu “público” que já vem como objeto único
-export const getPublicWeeklyMenu = async (): Promise<WeeklyMenu> => {
-  const { data } = await apiClient.get('/public/weekly/');
-  // garante que sempre exista o array days, nem que vazio
-  return { ...data, days: data.days ?? [] };
+export const getPublicWeeklyMenu = async (): Promise<WeeklyMenu | null> => {
+  try {
+    const { data } = await apiClient.get('/public/weekly/');
+    // garante que sempre exista o array days, nem que vazio
+    return { ...data, days: data.days ?? [] };
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      return null;
+    }
+    throw err;
+  }
 };
 
 /* — se quiser o endpoint de gestão —


### PR DESCRIPTION
## Summary
- raise 404 from `get_public_weekly_menu` when no menu exists
- allow frontend to return `null` if API responds 404
- handle nullable weekly menu in query hook

## Testing
- `npm run lint` *(fails: asks for ESLint configuration)*
- `npm run typecheck` *(fails: TypeScript errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68403b1b17cc8322aa23d4adc96f0de9