### PR TITLE
Fix admin weekly menu data structure

### DIFF
--- a/services/web/app/src/services/menuService.ts
+++ b/services/web/app/src/services/menuService.ts
@@ -31,8 +31,9 @@ export const listWeeklyMenus = async (): Promise<WeeklyMenu[]> => {
 
 // Example for admin-specific fetching if needed, may require authentication
 export const getAdminWeeklyMenu = async (): Promise<WeeklyMenu> => {
-  const response = await apiClient.get('/menus/weekly-admin/'); // Placeholder, adjust to actual admin endpoint
-  return response.data;
+  const { data } = await apiClient.get('/menus/weekly-admin/'); // Placeholder, adjust to actual admin endpoint
+  // Guarantee a valid array to avoid runtime errors when mapping over days
+  return { ...data, days: data.days ?? [] };
 };
 
 // Assuming an endpoint for updating a specific meal in a day menu


### PR DESCRIPTION
## Summary
- ensure getAdminWeeklyMenu always returns a `days` array

## Testing
- `npm run lint` *(fails: asks for configuration)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6840cb89beb88322ba37be731a539cbc